### PR TITLE
Convert temperature display to Celsius

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # My Weather App
 
-This is a simple weather application built with Flask. It allows users to enter a city name and get the current weather information for that city.
+This is a simple weather application built with Flask. It allows users to enter a city name and get the current weather information for that city. Now, the application displays temperature in Celsius degrees.
 
 # Installation
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,7 +16,7 @@
         <h2>Weather in {{ weather.city }}</h2>
         <img src="http://openweathermap.org/img/w/{{ weather.icon }}.png" alt="Weather icon">
         <p>{{ weather.description }}</p>
-        <p>Temperature: {{ weather.temperature }}</p>
+        <p>Temperature: {{ weather.temperature }}&deg;C</p>
     </div>
     {% endif %}
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>

--- a/app/views.py
+++ b/app/views.py
@@ -9,7 +9,8 @@ def index():
     if request.method == 'POST':
         city = request.form['city']
 
-        url = f'http://api.openweathermap.org/data/2.5/weather?q={city}&appid=b5268fcd2ca37ab2198170fac2825453'
+        # Added units=metric parameter to fetch temperature in Celsius
+        url = f'http://api.openweathermap.org/data/2.5/weather?q={city}&appid=b5268fcd2ca37ab2198170fac2825453&units=metric'
 
         response = requests.get(url).json()
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,3 +17,7 @@ class TestViews(unittest.TestCase):
             response = self.app.post('/', data={'city': city})
             self.assertEqual(response.status_code, 200)
             self.assertIn(bytes(city, 'utf-8'), response.data)
+
+    def test_temperature_display_in_celsius(self):
+        response = self.app.get('/')
+        self.assertIn(b'&deg;C', response.data, "Temperature should be displayed in Celsius degrees.")


### PR DESCRIPTION
Related to #2

Updates the weather application to display temperatures in Celsius degrees.

- **API Call Modification**: Modifies the API call in `app/views.py` to include the `units=metric` parameter, ensuring temperatures are fetched in Celsius.
- **Template Update**: Adjusts the temperature display in `app/templates/index.html` to specify that the temperature is in Celsius degrees.
- **Documentation Enhancement**: Adds a note in `README.md` highlighting that the application now displays temperature in Celsius degrees.
- **Testing**: Introduces a new test in `tests/test_views.py` to verify that temperatures are correctly displayed in Celsius.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SolidifyDemo/the-weather-app/issues/2?shareId=2e4c3be1-62c3-4efd-b20d-0239cfbea0bb).